### PR TITLE
Create the root and issuer cert keys and csrs in the mount point

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For example, to run a container, customise variables and mount the certificates
 in a volume:
 
 ```
-docker run \
+docker run --rm \
   -e COUNTY="ME" \
   -e STATE="Middle Earth" \
   -e LOCATION="The Shire" \


### PR DESCRIPTION
 so that they can be reused to issue certificates for other domains.
My usecase was to be able to issue multiple certificates for different servers using the same issuer and root CA.